### PR TITLE
Minimized number of layers and changed ADD to COPY.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,14 +1,11 @@
 FROM ubuntu:trusty
-MAINTAINER George Lewis <schvin@schvin.net>
+LABEL MAINTAINER="George Lewis <schvin@schvin.net>"
 
-RUN apt-get update
-RUN apt-get install -y sysstat make
+RUN apt-get update && \
+    apt-get install -y sysstat make
 
 RUN perl -MCPAN -e 'install Net::Statsd'
 
-ADD scripts/ingest.pl /usr/local/bin/
-ADD scripts/loop.pl /usr/local/bin/
-ADD scripts/periodic-ingest.sh /usr/local/bin/
-ADD scripts/runner.sh /usr/local/bin/
+COPY scripts/ingest.pl scripts/loop.pl scripts/periodic-ingest.sh scripts/runner.sh /usr/local/bin/
 
 CMD /usr/local/bin/runner.sh


### PR DESCRIPTION
It is preferred to minimzed the number of layers and to prefer `COPY` over `ADD` for basic file copying [reference](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#add-or-copy). `MAINTAINER` is deprecated and hence changed it to `LABEL`.